### PR TITLE
Turns off Guzzle's default behaviour

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -27,7 +27,7 @@ use GuzzleHttp\Client as GuzzleClient;
 
 class Client implements ClientInterface
 {
-    private const string SDK_VERSION = '0.4.1-php';
+    private const string SDK_VERSION = '0.4.2-php';
 
     private GuzzleClient $guzzleClient;
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -6,7 +6,9 @@ use Citadel\Action\SessionResolveBearerRequest;
 use Citadel\Action\SessionResolveRequest;
 use Citadel\Action\SessionRevokeBearerRequest;
 use Citadel\Action\SessionRevokeRequest;
+use Citadel\Exception\CitadelBaseException;
 use Citadel\Exception\ExceptionFactory;
+use Citadel\Exception\InternalServerErrorException;
 use Citadel\Exception\MalformedPayloadException;
 use Citadel\Exception\MalformedTimestampException;
 use Citadel\Interface\CitadelReportedExceptionInterface;
@@ -79,7 +81,9 @@ class Client implements ClientInterface
     }
 
     /**
+     * @throws InternalServerErrorException
      * @throws MalformedPayloadException
+     * @throws CitadelBaseException
      */
     public function sessionRevokeBearer(SessionRevokeBearerRequest $request): SessionRevokeBearerResponse
     {
@@ -89,7 +93,8 @@ class Client implements ClientInterface
     }
 
     /**
-     * @throws MalformedPayloadException|CitadelReportedExceptionInterface
+     * @throws InternalServerErrorException
+     * @throws MalformedPayloadException|CitadelReportedExceptionInterface|CitadelBaseException
      */
     private function sendRequest(
         string $action,
@@ -112,7 +117,8 @@ class Client implements ClientInterface
                 'Content-Type' => 'application/json',
                 'x-sdk-version' => self::SDK_VERSION
             ],
-            'body' => $requestBody
+            'body' => $requestBody,
+            'http_errors' => false
         ]);
 
         $statusCode = $response->getStatusCode();

--- a/src/Exception/CitadelBaseException.php
+++ b/src/Exception/CitadelBaseException.php
@@ -1,7 +1,6 @@
 <?php
 namespace Citadel\Exception;
 
-use Citadel\Interface\CitadelReportedExceptionInterface;
 use Exception;
 use Throwable;
 

--- a/src/Exception/ExceptionFactory.php
+++ b/src/Exception/ExceptionFactory.php
@@ -20,11 +20,18 @@ class ExceptionFactory
 
     /**
      * @throws CitadelReportedExceptionInterface
+     * @throws InternalServerErrorException
+     * @throws MalformedPayloadException|CitadelBaseException
      */
     public static function generateExceptionFromResponse(ResponseInterface $response) :never
     {
         $body = $response->getBody()->getContents();
         $statusCode = $response->getStatusCode();
+
+        if ($statusCode >= 500) {
+            throw new InternalServerErrorException("Citadel reported internal server error", $statusCode);
+        }
+
         try {
             $errorResponse = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
         } catch (\JsonException $e) {

--- a/src/Exception/InternalServerErrorException.php
+++ b/src/Exception/InternalServerErrorException.php
@@ -1,0 +1,6 @@
+<?php
+namespace Citadel\Exception;
+
+class InternalServerErrorException extends CitadelBaseException
+{
+}


### PR DESCRIPTION
Turns off Guzzle's default behaviour of throwing exceptions for 4xx and 5xx response codes. This allows the SDK to select and throw its own custom exceptions.

Added an InternalServerError exception class to cover the 5xx range of response status codes. 

Updated docblocks to reflect exception classes being thrown. 